### PR TITLE
SQLのテーブルにインデックスを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - mysql:/var/lib/mysql
       - ./etc/my.cnf:/etc/my.cnf
       - ./sql:/docker-entrypoint-initdb.d
+      - ./logs/mysql:/var/log/mysql
     ports:
       - "3306:3306"
     deploy:

--- a/etc/my.cnf
+++ b/etc/my.cnf
@@ -1,2 +1,5 @@
 [mysqld]
 default_authentication_plugin=mysql_native_password
+slow_query_log  = 1
+slow_query_log_file = /var/log/mysql/mysql-slow.log
+long_query_time = 0

--- a/sql/0001-add-post_id-index.down.sql
+++ b/sql/0001-add-post_id-index.down.sql
@@ -1,0 +1,2 @@
+USE isuconp;
+ALTER TABLE comments DROP INDEX post_id_index;

--- a/sql/0001-add-post_id-index.down.sql
+++ b/sql/0001-add-post_id-index.down.sql
@@ -1,2 +1,0 @@
-USE isuconp;
-ALTER TABLE comments DROP INDEX post_id_index;

--- a/sql/0001-add-post_id-index.up.sql
+++ b/sql/0001-add-post_id-index.up.sql
@@ -1,0 +1,2 @@
+USE isuconp;
+ALTER TABLE comments ADD INDEX post_id_index(post_id);

--- a/sql/0002-add-user_id-index.up.sql
+++ b/sql/0002-add-user_id-index.up.sql
@@ -1,0 +1,2 @@
+USE isuconp;
+ALTER TABLE posts ADD INDEX user_id_index(user_id);

--- a/sql/0003-add-user_id-index.down.sql
+++ b/sql/0003-add-user_id-index.down.sql
@@ -1,0 +1,2 @@
+USE isuconp;
+ALTER TABLE posts DROP INDEX user_id_index;

--- a/tools/mysql-slow-updater.sh
+++ b/tools/mysql-slow-updater.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sudo mv ../logs/mysql/mysql-slow.log ../logs/mysql/mysql-slow.log.old
+sudo touch ../logs/mysql/mysql-slow.log
+
+


### PR DESCRIPTION
## やったこと
SQLのログを確認したところ、特定のqueryの動作が重かったためインデックスを張った。
[実行したquery](https://github.com/YukiYuigishi/private-isu-golang/blob/master/sql/0001-add-post_id-index.up.sql)
```sql
ALTER TABLE comments DROP INDEX post_id_index;
```
### Pros
scoreが明確に向上し、リクエストのタイムアウトもなくなった。
変更前score
```
{"pass":true,"score":0,"success":175,"fail":64,"messages":["リクエストがタイムアウトしました (GET /)","リクエストがタイムアウトしました (GET /@alfreda)","リクエストがタイムアウトしました (GET /@bettie)","リクエストがタイムアウトしました (GET /@charlene)","リクエストがタイムアウトしました (GET /@charmaine)","リクエストがタイムアウトしました (GET /@darlene)","リクエストがタイムアウトしました (GET /@frankie)","リクエストがタイムアウトしました (GET /@laura)","リクエストがタイムアウトしました (GET /@leanna)","リクエストがタイムアウトしました (GET /@rhea)","リクエストがタイムアウトしました (GET /@traci)","リクエストがタイムアウトしました (POST /login)","リクエストがタイムアウトしました (POST /register)"]}
```
変更後score
```
{"pass":true,"score":16372,"success":15460,"fail":0,"messages":[]}
```
